### PR TITLE
Function that knows name of its argument

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ThreeBodyDecaysIO"
 uuid = "418e7ecf-680e-4cb5-ad61-5e2f006aefac"
 authors = ["Mikhail Mikhasenko <mikhail.mikhasenko@cern.ch>"]
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/docs/demo-lc2ppk-read.jl
+++ b/docs/demo-lc2ppk-read.jl
@@ -31,8 +31,11 @@ function (BW::BreitWignerWidthExpLikeBugg)(σ)
     1 / (m^2 - σ - 1im * m * Γt)
 end
 function ThreeBodyDecaysIO.dict2instance(::Type{BreitWignerWidthExpLikeBugg}, dict)
-    @unpack mass, width, slope = dict
-    return BreitWignerWidthExpLikeBugg(mass, width, slope)
+    @unpack mass, width, slope, x = dict
+    bw = BreitWignerWidthExpLikeBugg(mass, width, slope)
+    parameters = String[]
+    variables = [x]
+    return NamedArgFunc(bw, variables, parameters)
 end
 
 

--- a/src/HadronicLineshapesIO.jl
+++ b/src/HadronicLineshapesIO.jl
@@ -1,6 +1,30 @@
+# deserialization
+
+@with_kw struct NamedArgFunc{T,P,D}
+    f::T
+    variable_names::D
+    parameters::P = String[] # currently empty
+end
+
 function dict2instance(::Type{BreitWigner}, dict)
-    @unpack mass, width, ma, mb, l, d = dict
-    BreitWigner(mass, width, ma, mb, l, d)
+    @unpack mass, width, ma, mb, l, d, x = dict
+    bw = BreitWigner(mass, width, ma, mb, l, d)
+    parameters = String[]
+    variables = [x]
+    NamedArgFunc(bw, variables, parameters)
+end
+
+function dict2instance(::Type{MultichannelBreitWigner}, dict)
+    @unpack mass, channels, x = dict
+    # convert dict channels into NamedTuple
+    _channels = map(channels) do channel
+        @unpack gsq, ma, mb, l, d = channel
+        (; gsq, ma, mb, l, d)
+    end
+    bw = MultichannelBreitWigner(mass, _channels)
+    parameters = String[]
+    variables = [x]
+    return NamedArgFunc(bw, variables, parameters)
 end
 
 function dict2instance(::Type{BlattWeisskopf}, dict)
@@ -13,14 +37,31 @@ function dict2instance(::Type{MomentumPower}, dict)
     return MomentumPower{l}()
 end
 
-function dict2instance(::Type{MultichannelBreitWigner}, dict)
-    @unpack mass, channels = dict
-    # convert dict channels into NamedTuple
+
+
+# serialization
+
+function serializeToDict(obj::NamedArgFunc{BreitWigner})
+    type = "BreitWigner"
+    @unpack f, variable_names = obj
+    @unpack ma, mb, l, d = f
+    x = first(variable_names)
+    dict = LittleDict{Symbol,Any}(pairs((; type, mass=f.m, width=f.Γ, ma, mb, l, d, x)))
+    appendix = Dict()
+    return (dict, appendix)
+end
+function serializeToDict(obj::NamedArgFunc{<:MultichannelBreitWigner})
+    type = "MultichannelBreitWigner"
+    @unpack f, variable_names = obj
+    @unpack m, channels = f
+    x = first(variable_names)
     _channels = map(channels) do channel
         @unpack gsq, ma, mb, l, d = channel
-        (; gsq, ma, mb, l, d)
+        LittleDict{Symbol,Any}(pairs((; gsq, ma, mb, l, d)))
     end
-    return MultichannelBreitWigner(mass, _channels)
+    appendix = Dict()
+    dict = LittleDict{Symbol,Any}(pairs((; type, mass=m, channels=_channels, x)))
+    return (dict, appendix)
 end
 
 
@@ -37,23 +78,5 @@ function serializeToDict(x::MomentumPower)
     type = "MomentumPower"
     dict = LittleDict{Symbol,Any}(pairs((; type, l)))
     appendix = Dict()
-    return (dict, appendix)
-end
-function serializeToDict(x::BreitWigner)
-    type = "BreitWigner"
-    @unpack ma, mb, l, d = x
-    dict = LittleDict{Symbol,Any}(pairs((; type, mass=x.m, width=x.Γ, ma, mb, l, d)))
-    appendix = Dict()
-    return (dict, appendix)
-end
-function serializeToDict(dict::MultichannelBreitWigner)
-    type = "MultichannelBreitWigner"
-    @unpack m, channels = dict
-    _channels = map(channels) do channel
-        @unpack gsq, ma, mb, l, d = channel
-        LittleDict{Symbol,Any}(pairs((; gsq, ma, mb, l, d)))
-    end
-    appendix = Dict()
-    dict = LittleDict{Symbol,Any}(pairs((; type, mass=m, channels=_channels)))
     return (dict, appendix)
 end

--- a/src/HadronicLineshapesIO.jl
+++ b/src/HadronicLineshapesIO.jl
@@ -6,6 +6,15 @@
     parameters::P = String[] # currently empty
 end
 
+
+result = replace(["a", "a"], "a" => 1)
+
+function (obj::NamedArgFunc)(dict::AbstractDict)
+    @unpack variable_names = obj
+    variable_value = dict[first(variable_names)]
+    obj.f(variable_value)
+end
+
 function dict2instance(::Type{BreitWigner}, dict)
     @unpack mass, width, ma, mb, l, d, x = dict
     bw = BreitWigner(mass, width, ma, mb, l, d)

--- a/src/HadronicUnpolarizedIntensity.jl
+++ b/src/HadronicUnpolarizedIntensity.jl
@@ -3,7 +3,7 @@
 @with_kw struct HadronicUnpolarizedIntensity{M,P,D}
     model::M
     reference_k::Int
-    parameters::P
+    parameters::P # currently empty
     mass_angles_cascade_names::D
 end
 
@@ -16,8 +16,8 @@ end
 
 function dict2instance(::Type{HadronicUnpolarizedIntensity}, dict; workspace)
     @unpack decay_description = dict
-    parameters = haskey(dict, "parameters") ? dict["parameters"] : []
-    variables = haskey(dict, "variables") ? dict["variables"] : []
+    parameters = haskey(dict, "parameters") ? dict["parameters"] : String[]
+    variables = haskey(dict, "variables") ? dict["variables"] : String[]
     model = dict2instance(ThreeBodyDecay, decay_description; workspace)
     # 
     @unpack reference_topology = decay_description

--- a/src/ThreeBodyDecaysIO.jl
+++ b/src/ThreeBodyDecaysIO.jl
@@ -15,6 +15,7 @@ export add_hs3_fields
 export trivial_lineshape_parser
 include("writer.jl")
 
+export NamedArgFunc
 include("HadronicLineshapesIO.jl")
 export generic_function
 include("generic_function.jl")

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -66,22 +66,21 @@ function dict2instance(::Type{DecayChain}, dict; tbs, workspace=Dict())
 
     # build lineshape
     scattering = resonance["parametrization"]
-    bw = scattering isa Dict ? dict2instance(scattering) : workspace[scattering]
-    X = bw
+    scattering isa Dict && error("Deserialization of lineshape directly from the chains is not implemented yet. Use `functions` field instead.")
+    !(scattering isa String) && error("The scattering should be a string. Got: $scattering")
+    X = workspace[scattering].f
     if vertex_Rk["formfactor"] != ""
-        FF_Rk = build_or_fetch(vertex_Rk["formfactor"], workspace)
-        # single variablre function for the form factor
-        @unpack ms = tbs
         # for 0->Rk decay
+        FF_Rk = build_or_fetch(vertex_Rk["formfactor"], workspace)
+        @unpack ms = tbs
         p(σ) = HadronicLineshapes.breakup(ms[4], sqrt(σ), ms[k])
         FF_Rk_svf = FF_Rk(p)
         X *= FF_Rk_svf
     end
     if vertex_ij["formfactor"] != ""
-        FF_ij = build_or_fetch(vertex_ij["formfactor"], workspace)
-        # single variablre function for the form factor
-        @unpack ms = tbs
         # for R->ij decay
+        FF_ij = build_or_fetch(vertex_ij["formfactor"], workspace)
+        @unpack ms = tbs
         q(σ) = HadronicLineshapes.breakup(sqrt(σ), ms[i], ms[j])
         FF_ij_svf = FF_ij(q)
         X *= FF_ij_svf

--- a/test/lc2ppi-lhcb-test.json
+++ b/test/lc2ppi-lhcb-test.json
@@ -755,6 +755,7 @@
   "functions": [
     {
       "name": "L1405_Flatte",
+      "x": "m_Kp^2",
       "type": "MultichannelBreitWigner",
       "mass": 1.4051,
       "channels": [
@@ -776,6 +777,7 @@
     },
     {
       "name": "L1690_BW",
+      "x": "m_Kp^2",
       "l": 2,
       "mb": 0.938272046,
       "type": "BreitWigner",
@@ -786,6 +788,7 @@
     },
     {
       "name": "D1232_BW",
+      "x": "m_Kp^2",
       "l": 1,
       "mb": 0.13957018,
       "type": "BreitWigner",
@@ -796,6 +799,7 @@
     },
     {
       "name": "L1520_BW",
+      "x": "m_Kp^2",
       "l": 2,
       "mb": 0.938272046,
       "type": "BreitWigner",
@@ -806,6 +810,7 @@
     },
     {
       "name": "L1600_BW",
+      "x": "m_Kp^2",
       "l": 1,
       "mb": 0.938272046,
       "type": "BreitWigner",
@@ -816,6 +821,7 @@
     },
     {
       "name": "L2000_BW",
+      "x": "m_Kp^2",
       "l": 0,
       "mb": 0.938272046,
       "type": "BreitWigner",
@@ -826,6 +832,7 @@
     },
     {
       "name": "D1600_BW",
+      "x": "m_ppi^2",
       "l": 1,
       "mb": 0.13957018,
       "type": "BreitWigner",
@@ -836,6 +843,7 @@
     },
     {
       "name": "D1700_BW",
+      "x": "m_ppi^2",
       "l": 2,
       "mb": 0.13957018,
       "type": "BreitWigner",
@@ -846,6 +854,7 @@
     },
     {
       "name": "K892_BW",
+      "x": "m_Kpi^2",
       "l": 1,
       "mb": 0.493677,
       "type": "BreitWigner",
@@ -856,6 +865,7 @@
     },
     {
       "name": "K700_BuggBW",
+      "x": "m_Kpi^2",
       "slope": 0.94106,
       "type": "BreitWignerWidthExpLikeBugg",
       "mass": 0.824,
@@ -863,6 +873,7 @@
     },
     {
       "name": "K1430_BuggBW",
+      "x": "m_Kpi^2",
       "slope": 0.020981,
       "type": "BreitWignerWidthExpLikeBugg",
       "mass": 1.375,
@@ -870,6 +881,7 @@
     },
     {
       "name": "L1670_BW",
+      "x": "m_Kp^2",
       "l": 0,
       "mb": 0.938272046,
       "type": "BreitWigner",

--- a/test/test_lineshape_reader.jl
+++ b/test/test_lineshape_reader.jl
@@ -4,11 +4,18 @@ using ThreeBodyDecaysIO.OrderedCollections
 using Test
 
 
-# @testset "BreitWigner from plane Dict" begin
-let
-    d = Dict("type" => "BreitWigner", "name" => "L1520_BW", "mass" => 1.0, "width" => 0.1, "ma" => 0.0, "mb" => 0.0, "l" => 0, "d" => 1.5, "x" => "m23sq")
+@testset "BreitWigner from plane Dict" begin
+    d = Dict("type" => "BreitWigner",
+        "name" => "L1520_BW",
+        "mass" => 1.0, "width" => 0.1,
+        "ma" => 0.0, "mb" => 0.0,
+        "l" => 0, "d" => 1.5, "x" => "m23sq")
     bw1 = dict2instance(BreitWigner, d)
     @test bw1 isa NamedArgFunc{<:HadronicLineshapes.AbstractFlexFunc,Vector{String},Vector{String}}
+    @test bw1(Dict("m23sq" => 1.1)) ≈ -5 + 5im
+    @test bw1(LittleDict("m23sq" => 1.1)) ≈ -5 + 5im
+    @test bw1(OrderedDict("m23sq" => 1.1)) ≈ -5 + 5im
+    @test_throws KeyError bw1(LittleDict("msq" => 1.1))
 end
 
 

--- a/test/test_lineshape_reader.jl
+++ b/test/test_lineshape_reader.jl
@@ -4,11 +4,14 @@ using ThreeBodyDecaysIO.OrderedCollections
 using Test
 
 
-@testset "BreitWigner from plane Dict" begin
-    d = Dict("type" => "BreitWigner", "name" => "L1520_BW", "mass" => 1.0, "width" => 0.1, "ma" => 0.0, "mb" => 0.0, "l" => 0, "d" => 1.5)
+# @testset "BreitWigner from plane Dict" begin
+let
+    d = Dict("type" => "BreitWigner", "name" => "L1520_BW", "mass" => 1.0, "width" => 0.1, "ma" => 0.0, "mb" => 0.0, "l" => 0, "d" => 1.5, "x" => "m23sq")
     bw1 = dict2instance(BreitWigner, d)
-    @test bw1 isa HadronicLineshapes.AbstractFlexFunc
+    @test bw1 isa NamedArgFunc{<:HadronicLineshapes.AbstractFlexFunc,Vector{String},Vector{String}}
 end
+
+
 
 @testset "MomentumPower from plane Dict" begin
     d = Dict("type" => "MomentumPower", "l" => 5)
@@ -24,19 +27,19 @@ end
 end
 
 @testset "MultichannelBreitWigner from a nasted Dict" begin
-    d = LittleDict("type" => "MultichannelBreitWigner", "name" => "L1520_BW", "mass" => 1.0, "channels" => [LittleDict("gsq" => 0.1, "ma" => 0.0, "mb" => 0.0, "l" => 0, "d" => 1.5)])
+    d = LittleDict("type" => "MultichannelBreitWigner", "name" => "L1520_BW", "mass" => 1.0, "channels" => [LittleDict("gsq" => 0.1, "ma" => 0.0, "mb" => 0.0, "l" => 0, "d" => 1.5)], "x" => "msq")
     bw1 = dict2instance(MultichannelBreitWigner, d)
-    @test bw1 isa HadronicLineshapes.AbstractFlexFunc
+    @show typeof(bw1)
+    @test bw1 isa NamedArgFunc{<:HadronicLineshapes.AbstractFlexFunc,Vector{String},Vector{String}}
 end
 
 @testset "Deserialize MultichannelBreitWigner" begin
-    d = LittleDict("type" => "MultichannelBreitWigner", "name" => "L1520_BW", "mass" => 1.0,
+    d = LittleDict("type" => "MultichannelBreitWigner", "name" => "L1520_BW", "mass" => 1.0, "x" => "msq",
         "channels" => [
             LittleDict("gsq" => 1.1, "ma" => 0.1, "mb" => 0.2, "l" => 1, "d" => 1.5),
             LittleDict("gsq" => 2.1, "ma" => 1.0, "mb" => 2.0, "l" => 3, "d" => 1.5)])
     bw1 = dict2instance(MultichannelBreitWigner, d)
     dict, _ = serializeToDict(bw1)
-
     @test all(values(dict[:channels][1]) .== values(d["channels"][1]))
     @test all(values(dict[:channels][2]) .== values(d["channels"][2]))
 end

--- a/test/test_model_content.jl
+++ b/test/test_model_content.jl
@@ -60,10 +60,12 @@ function (BW::BreitWignerWidthExpLikeBugg)(σ)
     1 / (m^2 - σ - 1im * m * Γt)
 end
 function ThreeBodyDecaysIO.dict2instance(::Type{BreitWignerWidthExpLikeBugg}, dict)
-    @unpack mass, width, slope = dict
-    return BreitWignerWidthExpLikeBugg(mass, width, slope)
+    @unpack mass, width, slope, x = dict
+    bw = BreitWignerWidthExpLikeBugg(mass, width, slope)
+    parameters = String[]
+    variables = [x]
+    return NamedArgFunc(bw, variables, parameters)
 end
-
 
 let
     @info "⭐ Reading model from $test_file_name ⭐"

--- a/test/test_write_read_model.jl
+++ b/test/test_write_read_model.jl
@@ -60,7 +60,8 @@ end
 
 
 decay_description, appendix = serializeToDict(model; lineshape_parser)
-dict = add_hs3_fields(decay_description, appendix, "Lc2pKpi-default-model")
+appendix["K892_BW"][:x] = "sigma"
+dict = add_hs3_fields(decay_description, appendix, "default-model")
 
 open("test.json", "w") do io
     JSON.print(io, dict, 4)


### PR DESCRIPTION
The PR implements a wrapper for some of the hadronic lineshapes (`BreitWigner`, and `MultichannelBreitWigner`).
They are deserialized as `NamedArgFunc`, however, passed into `ThreeBodyDecay` object as callable object.

The wrapper is needed to implement calling it on `Dict` with named parameters.